### PR TITLE
Add support for materials and groups

### DIFF
--- a/examples/geometry.js
+++ b/examples/geometry.js
@@ -176,6 +176,7 @@ async function init() {
 		opacity: 0.15,
 		transparent: true,
 	} ) );
+	wireframeResult.material.color.set( 0x001516 ).convertSRGBToLinear();
 	scene.add( wireframeResult );
 
 	// gui

--- a/examples/geometry.js
+++ b/examples/geometry.js
@@ -100,7 +100,7 @@ async function init() {
 	geometry.computeVertexNormals();
 
 	// initialize brushes
-	bunnyBrush = new Brush( gltf.scene.children[ 0 ].geometry, new THREE.MeshStandardMaterial() );
+	bunnyBrush = new Brush( geometry, new THREE.MeshStandardMaterial() );
 	bunnyBrush.position.y = - 0.5;
 	bunnyBrush.updateMatrixWorld();
 
@@ -205,13 +205,16 @@ function updateCSG() {
 
 	const startTime = window.performance.now();
 	let finalBrush = brushes[ 0 ];
+	csgEvaluator.useGroups = false;
 	for ( let i = 1, l = brushes.length; i < l; i ++ ) {
 
 		const b = brushes[ i ];
-		finalBrush = new Brush( csgEvaluator.evaluate( finalBrush, b, ADDITION ) );
+		finalBrush = csgEvaluator.evaluate( finalBrush, b, ADDITION );
+		finalBrush.material = material;
 
 	}
 
+	csgEvaluator.useGroups = true;
 	csgEvaluator.evaluate( bunnyBrush, finalBrush, params.operation, resultObject.geometry );
 
 	const deltaTime = window.performance.now() - startTime;

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -33,6 +33,7 @@ const params = {
 	displayControls: true,
 	shadows: true,
 	vertexColors: false,
+	flatShading: false,
 
 	enableDebugTelemetry: true,
 	displayIntersectionEdges: false,
@@ -215,14 +216,35 @@ function init() {
 		brush2.material.vertexColors = v;
 		brush2.material.needsUpdate = true;
 
-		resultObject.material.vertexColors = v;
-		resultObject.material.needsUpdate = true;
+		materialMap.forEach( m => {
+
+			m.vertexColors = v;
+			m.needsUpdate = true;
+
+		} );
 
 		csgEvaluator.attributes = v ?
 			[ 'color', 'position', 'uv', 'normal' ] :
 			[ 'position', 'uv', 'normal' ];
 
 		needsUpdate = true;
+
+	} );
+
+	gui.add( params, 'flatShading' ).onChange( v => {
+
+		brush1.material.flatShading = v;
+		brush1.material.needsUpdate = true;
+
+		brush2.material.flatShading = v;
+		brush2.material.needsUpdate = true;
+
+		materialMap.forEach( m => {
+
+			m.flatShading = v;
+			m.needsUpdate = true;
+
+		} );
 
 	} );
 

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -367,7 +367,7 @@ function render() {
 
 		const startTime = window.performance.now();
 		csgEvaluator.debug.enabled = enableDebugTelemetry;
-		csgEvaluator.evaluate( brush1, brush2, params.operation, resultObject.geometry );
+		csgEvaluator.evaluate( brush1, brush2, params.operation, resultObject );
 
 		const deltaTime = window.performance.now() - startTime;
 		outputContainer.innerText = `${ deltaTime.toFixed( 3 ) }ms`;

--- a/src/core/Brush.js
+++ b/src/core/Brush.js
@@ -8,6 +8,7 @@ export class Brush extends Mesh {
 
 		super( ...args );
 
+		this.isBrush = true;
 		this._previousMatrix = new Matrix4();
 		this._previousMatrix.elements.fill( 0 );
 

--- a/src/core/Evaluator.js
+++ b/src/core/Evaluator.js
@@ -88,6 +88,7 @@ export class Evaluator {
 		this.triangleSplitter = new TriangleSplitter();
 		this.attributeData = new TypedAttributeData();
 		this.attributes = [ 'position', 'uv', 'normal' ];
+		this.useGroups = true;
 		this.debug = new OperationDebugData();
 
 	}
@@ -137,7 +138,7 @@ export class Evaluator {
 
 		}
 
-		performOperation( a, b, operation, triangleSplitter, attributeData );
+		const { groups, materials } = performOperation( a, b, operation, triangleSplitter, attributeData, { useGroups: this.useGroups } );
 
 		if ( debug.enabled ) {
 

--- a/src/core/Evaluator.js
+++ b/src/core/Evaluator.js
@@ -4,6 +4,7 @@ import { TypedAttributeData } from './TypedAttributeData.js';
 import { OperationDebugData } from './OperationDebugData.js';
 import { performOperation } from './operations.js';
 import { setDebugContext } from './operationsUtils.js';
+import { Brush } from './Brush.js';
 
 // applies the given set of attribute data to the provided geometry. If the attributes are
 // not large enough to hold the new set of data then new attributes will be created. Otherwise
@@ -93,12 +94,13 @@ export class Evaluator {
 
 	}
 
-	evaluate( a, b, operation, targetGeometry = new BufferGeometry() ) {
+	evaluate( a, b, operation, targetBrush = new Brush() ) {
 
 		a.prepareGeometry();
 		b.prepareGeometry();
 
 		const { triangleSplitter, attributeData, attributes, debug } = this;
+		const targetGeometry = targetBrush.geometry;
 		const aAttributes = a.geometry.attributes;
 		for ( let i = 0, l = attributes.length; i < l; i ++ ) {
 
@@ -146,7 +148,18 @@ export class Evaluator {
 
 		}
 
-		return applyToGeometry( targetGeometry, a.geometry, attributeData.attributes );
+		applyToGeometry( targetGeometry, a.geometry, attributeData.attributes );
+
+		targetBrush.material = materials || targetBrush.material;
+		targetGeometry.clearGroups();
+		for ( let i = 0, l = groups.length; i < l; i ++ ) {
+
+			const group = groups[ i ];
+			targetGeometry.addGroup( group.start, group.count, group.materialIndex );
+
+		}
+
+		return targetBrush;
 
 	}
 

--- a/src/core/Evaluator.js
+++ b/src/core/Evaluator.js
@@ -1,4 +1,4 @@
-import { BufferGeometry, BufferAttribute } from 'three';
+import { BufferAttribute } from 'three';
 import { TriangleSplitter } from './TriangleSplitter.js';
 import { TypedAttributeData } from './TypedAttributeData.js';
 import { OperationDebugData } from './OperationDebugData.js';

--- a/src/core/IntersectionMap.js
+++ b/src/core/IntersectionMap.js
@@ -1,0 +1,24 @@
+export class IntersectionMap {
+
+	constructor() {
+
+		this.intersectionSet = {};
+		this.ids = [];
+
+	}
+
+	add( id, intersectionId ) {
+
+		const { intersectionSet, ids } = this;
+		if ( ! intersectionSet[ id ] ) {
+
+			intersectionSet[ id ] = [];
+			ids.push( id );
+
+		}
+
+		intersectionSet[ id ].push( intersectionId );
+
+	}
+
+}

--- a/src/core/Operation.js
+++ b/src/core/Operation.js
@@ -6,9 +6,10 @@ export class Operation extends Brush {
 	constructor() {
 
 		super( null, null );
+
+		this.isOperation = true;
 		this.operation = PASSTHROUGH;
 		this._previousOperation = null;
-
 		this._geometrySet = [];
 
 	}

--- a/src/core/operations.js
+++ b/src/core/operations.js
@@ -49,7 +49,7 @@ export function performOperation( a, b, operation, splitter, typedAttributeData,
 
 	function processWithGroups( a, b, triSet, invert ) {
 
-		const groups = JSON.parse( JSON.stringify( a.geometry.groups ) );
+		const groups = [ ...a.geometry.groups ];
 		if ( groups.length === 0 ) {
 
 			groups.push( {

--- a/src/core/operations.js
+++ b/src/core/operations.js
@@ -47,7 +47,7 @@ export function performOperation( a, b, operation, splitter, typedAttributeData 
 
 			groups.push( {
 				start: 0,
-				count: a.geometry.attributes.position.count,
+				count: Infinity,
 				materialIndex: 0
 			} );
 

--- a/src/core/operations.js
+++ b/src/core/operations.js
@@ -100,8 +100,11 @@ function performSplitTriangleOperations( a, b, triSets, operation, invert, split
 
 	_normalMatrix.getNormalMatrix( a.matrixWorld );
 
+	const aIndex = a.geometry.index;
 	const aPosition = a.geometry.attributes.position;
+
 	const bBVH = b.geometry.boundsTree;
+	const bIndex = b.geometry.index;
 	const bPosition = b.geometry.attributes.position;
 
 	// iterate over all split triangle indices
@@ -125,9 +128,9 @@ function performSplitTriangleOperations( a, b, triSets, operation, invert, split
 
 		// get the triangle in the geometry B local frame
 		const ia3 = 3 * ia;
-		const ia0 = ia3 + 0;
-		const ia1 = ia3 + 1;
-		const ia2 = ia3 + 2;
+		const ia0 = aIndex.getX( ia3 + 0 );
+		const ia1 = aIndex.getX( ia3 + 1 );
+		const ia2 = aIndex.getX( ia3 + 2 );
 		_triA.a.fromBufferAttribute( aPosition, ia0 ).applyMatrix4( _matrix );
 		_triA.b.fromBufferAttribute( aPosition, ia1 ).applyMatrix4( _matrix );
 		_triA.c.fromBufferAttribute( aPosition, ia2 ).applyMatrix4( _matrix );
@@ -139,9 +142,9 @@ function performSplitTriangleOperations( a, b, triSets, operation, invert, split
 		for ( let ib = 0, l = intersectingIndices.length; ib < l; ib ++ ) {
 
 			const ib3 = 3 * intersectingIndices[ ib ];
-			const ib0 = ib3 + 0;
-			const ib1 = ib3 + 1;
-			const ib2 = ib3 + 2;
+			const ib0 = bIndex.getX( ib3 + 0 );
+			const ib1 = bIndex.getX( ib3 + 1 );
+			const ib2 = bIndex.getX( ib3 + 2 );
 			_triB.a.fromBufferAttribute( bPosition, ib0 );
 			_triB.b.fromBufferAttribute( bPosition, ib1 );
 			_triB.c.fromBufferAttribute( bPosition, ib2 );
@@ -185,7 +188,7 @@ function performSplitTriangleOperations( a, b, triSets, operation, invert, split
 }
 
 // perform CSG operations on the set of whole triangles
-function performWholeTriangleOperations( a, b, splitTriSet, operation, invert, attributeInfo, group ) {
+function performWholeTriangleOperations( a, b, splitTriSet, operation, invert, attributeInfo ) {
 
 	// matrix for transforming into the local frame of geometry b
 	_matrix
@@ -196,9 +199,10 @@ function performWholeTriangleOperations( a, b, splitTriSet, operation, invert, a
 	_normalMatrix.getNormalMatrix( a.matrixWorld );
 
 	const bBVH = b.geometry.boundsTree;
+	const aIndex = a.geometry.index;
 	const aAttributes = a.geometry.attributes;
 	const aPosition = aAttributes.position;
-	for ( let i = 0, l = aPosition.count / 3; i < l; i ++ ) {
+	for ( let i = 0, l = aIndex.count / 3; i < l; i ++ ) {
 
 		// if we find the index in the set of triangles that is supposed to be clipped
 		// then ignore it because it will be handled separately
@@ -208,24 +212,11 @@ function performWholeTriangleOperations( a, b, splitTriSet, operation, invert, a
 
 		}
 
-		// skip triangles outside of this group
-		// TODO: we could make this a lot faster
-		if ( group ) {
-
-			const relativeIndex = 3 * i - group.start;
-			if ( relativeIndex < 0 || relativeIndex >= group.count ) {
-
-				continue;
-
-			}
-
-		}
-
 		// get the vertex indices
 		const i3 = 3 * i;
-		const i0 = i3 + 0;
-		const i1 = i3 + 1;
-		const i2 = i3 + 2;
+		const i0 = aIndex.getX( i3 + 0 );
+		const i1 = aIndex.getX( i3 + 1 );
+		const i2 = aIndex.getX( i3 + 2 );
 
 		// get the vertex position in the frame of geometry b so we can
 		// perform hit testing

--- a/src/core/operations.js
+++ b/src/core/operations.js
@@ -40,11 +40,8 @@ function performSplitTriangleOperations( a, b, triSets, operation, invert, split
 
 	_normalMatrix.getNormalMatrix( a.matrixWorld );
 
-	const aIndex = a.geometry.index;
 	const aPosition = a.geometry.attributes.position;
-
 	const bBVH = b.geometry.boundsTree;
-	const bIndex = b.geometry.index;
 	const bPosition = b.geometry.attributes.position;
 
 	// iterate over all split triangle indices
@@ -55,9 +52,9 @@ function performSplitTriangleOperations( a, b, triSets, operation, invert, split
 		// get the triangle in the geometry B local frame
 		const ia = parseInt( key );
 		const ia3 = 3 * ia;
-		const ia0 = aIndex.getX( ia3 + 0 );
-		const ia1 = aIndex.getX( ia3 + 1 );
-		const ia2 = aIndex.getX( ia3 + 2 );
+		const ia0 = ia3 + 0;
+		const ia1 = ia3 + 1;
+		const ia2 = ia3 + 2;
 		_triA.a.fromBufferAttribute( aPosition, ia0 ).applyMatrix4( _matrix );
 		_triA.b.fromBufferAttribute( aPosition, ia1 ).applyMatrix4( _matrix );
 		_triA.c.fromBufferAttribute( aPosition, ia2 ).applyMatrix4( _matrix );
@@ -69,9 +66,9 @@ function performSplitTriangleOperations( a, b, triSets, operation, invert, split
 		for ( let ib = 0, l = intersectingIndices.length; ib < l; ib ++ ) {
 
 			const ib3 = 3 * intersectingIndices[ ib ];
-			const ib0 = bIndex.getX( ib3 + 0 );
-			const ib1 = bIndex.getX( ib3 + 1 );
-			const ib2 = bIndex.getX( ib3 + 2 );
+			const ib0 = ib3 + 0;
+			const ib1 = ib3 + 1;
+			const ib2 = ib3 + 2;
 			_triB.a.fromBufferAttribute( bPosition, ib0 );
 			_triB.b.fromBufferAttribute( bPosition, ib1 );
 			_triB.c.fromBufferAttribute( bPosition, ib2 );
@@ -127,10 +124,9 @@ function performWholeTriangleOperations( a, b, splitTriSet, operation, invert, a
 
 
 	const bBVH = b.geometry.boundsTree;
-	const aIndex = a.geometry.index;
 	const aAttributes = a.geometry.attributes;
 	const aPosition = aAttributes.position;
-	for ( let i = 0, l = aIndex.count / 3; i < l; i ++ ) {
+	for ( let i = 0, l = aPosition.count / 3; i < l; i ++ ) {
 
 		// if we find the index in the set of triangles that is supposed to be clipped
 		// then ignore it because it will be handled separately
@@ -142,9 +138,9 @@ function performWholeTriangleOperations( a, b, splitTriSet, operation, invert, a
 
 		// get the vertex indices
 		const i3 = 3 * i;
-		const i0 = aIndex.getX( i3 + 0 );
-		const i1 = aIndex.getX( i3 + 1 );
-		const i2 = aIndex.getX( i3 + 2 );
+		const i0 = i3 + 0;
+		const i1 = i3 + 1;
+		const i2 = i3 + 2;
 
 		// get the vertex position in the frame of geometry b so we can
 		// perform hit testing

--- a/src/core/operationsUtils.js
+++ b/src/core/operationsUtils.js
@@ -94,17 +94,11 @@ export function collectIntersectingTriangles( a, b ) {
 		.invert()
 		.multiply( b.matrixWorld );
 
-	const aIndex = a.geometry.index;
-	const bIndex = b.geometry.index;
-
 	a.geometry.boundsTree.bvhcast( b.geometry.boundsTree, _matrix, {
 
 		intersectsTriangles( triangleA, triangleB, ia, ib ) {
 
 			if ( triangleA.intersectsTriangle( triangleB, _debugContext ? _edge : undefined ) ) {
-
-				if ( aIndex ) ia = aIndex.getX( ia * 3 ) / 3;
-				if ( bIndex ) ib = bIndex.getX( ib * 3 ) / 3;
 
 				if ( ! aToB[ ia ] ) aToB[ ia ] = [];
 				if ( ! bToA[ ib ] ) bToA[ ib ] = [];
@@ -135,10 +129,11 @@ export function collectIntersectingTriangles( a, b ) {
 export function appendAttributeFromTriangle( triIndex, baryCoordTri, geometry, matrixWorld, normalMatrix, attributeInfo, invert ) {
 
 	const attributes = geometry.attributes;
+	const indexAttr = geometry.index;
 	const i3 = triIndex * 3;
-	const i0 = i3 + 0;
-	const i1 = i3 + 1;
-	const i2 = i3 + 2;
+	const i0 = indexAttr.getX( i3 + 0 );
+	const i1 = indexAttr.getX( i3 + 1 );
+	const i2 = indexAttr.getX( i3 + 2 );
 
 	for ( const key in attributeInfo ) {
 

--- a/src/core/operationsUtils.js
+++ b/src/core/operationsUtils.js
@@ -94,11 +94,17 @@ export function collectIntersectingTriangles( a, b ) {
 		.invert()
 		.multiply( b.matrixWorld );
 
+	const aIndex = a.geometry.index;
+	const bIndex = b.geometry.index;
+
 	a.geometry.boundsTree.bvhcast( b.geometry.boundsTree, _matrix, {
 
 		intersectsTriangles( triangleA, triangleB, ia, ib ) {
 
 			if ( triangleA.intersectsTriangle( triangleB, _debugContext ? _edge : undefined ) ) {
+
+				if ( aIndex ) ia = aIndex.getX( ia * 3 ) / 3;
+				if ( bIndex ) ib = bIndex.getX( ib * 3 ) / 3;
 
 				if ( ! aToB[ ia ] ) aToB[ ia ] = [];
 				if ( ! bToA[ ib ] ) bToA[ ib ] = [];
@@ -129,11 +135,10 @@ export function collectIntersectingTriangles( a, b ) {
 export function appendAttributeFromTriangle( triIndex, baryCoordTri, geometry, matrixWorld, normalMatrix, attributeInfo, invert ) {
 
 	const attributes = geometry.attributes;
-	const indexAttr = geometry.index;
 	const i3 = triIndex * 3;
-	const i0 = indexAttr.getX( i3 + 0 );
-	const i1 = indexAttr.getX( i3 + 1 );
-	const i2 = indexAttr.getX( i3 + 2 );
+	const i0 = i3 + 0;
+	const i1 = i3 + 1;
+	const i2 = i3 + 2;
 
 	for ( const key in attributeInfo ) {
 

--- a/src/core/operationsUtils.js
+++ b/src/core/operationsUtils.js
@@ -1,4 +1,5 @@
 import { Ray, Matrix4, DoubleSide, Vector3, Vector4, Triangle, Line3 } from 'three';
+import { IntersectionMap } from './IntersectionMap.js';
 import { ADDITION, SUBTRACTION, INTERSECTION, DIFFERENCE, PASSTHROUGH } from './constants.js';
 
 const _ray = new Ray();
@@ -86,8 +87,8 @@ export function getHitSide( tri, bvh ) {
 // the other triangles intersected
 export function collectIntersectingTriangles( a, b ) {
 
-	const aToB = {};
-	const bToA = {};
+	const aIntersections = new IntersectionMap();
+	const bIntersections = new IntersectionMap();
 
 	_matrix
 		.copy( a.matrixWorld )
@@ -100,11 +101,8 @@ export function collectIntersectingTriangles( a, b ) {
 
 			if ( triangleA.intersectsTriangle( triangleB, _debugContext ? _edge : undefined ) ) {
 
-				if ( ! aToB[ ia ] ) aToB[ ia ] = [];
-				if ( ! bToA[ ib ] ) bToA[ ib ] = [];
-
-				aToB[ ia ].push( ib );
-				bToA[ ib ].push( ia );
+				aIntersections.add( ia, ib );
+				bIntersections.add( ib, ia );
 
 				if ( _debugContext ) {
 
@@ -121,7 +119,7 @@ export function collectIntersectingTriangles( a, b ) {
 
 	} );
 
-	return { aToB, bToA };
+	return { aIntersections, bIntersections };
 
 }
 


### PR DESCRIPTION
Fix #5 

**TODO**
- [x] Operate on position buffer indices instead of index
- [x] Append triangles in group order
- [x] Is it really necessary to avoid using an index? It could just be an optimization suggestion once three-mesh-bvh supports no index
- [x] Reverting the index changes (d459375) caused a steep decline in performance. Why? (missing logic)
- [x] Add option & optimization to ignore groups to the Evaluator
- [x] Reassign groups
- [x] Update materials
- [x] Update evaluator to take a Brush or Mesh
- [x] Update demos
- [x] Optimize processing
  - both functions need to return where in the array they ended so they can start again at the right spot.

**FUTURE**
- Ensure the geometry is not indexed when creating the BVH so an optimal version is created
- Add option to three-mesh-bvh to store a newly created index internally (which would then mean groups can be ignored)
- Add utility for "consolidating" groups on geometry - ie reduce the number of groups / materials required by rearranging geometry.  (#40)
- How will we handle materials when using the half-edge approach?

![image](https://user-images.githubusercontent.com/734200/174461269-6ad96be8-ba32-4a7c-b101-36dfae4dd465.png)

![image](https://user-images.githubusercontent.com/734200/174464599-09096ba6-9bfa-4b37-a6eb-c89bba260e9a.png)
