### PR TITLE
Add Array types to array definitions. Fix optional parameter.

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -18,7 +18,7 @@ export class TypedAttributeData {
   getType( name: String ): string;
   getTotalLength( name: String ): number;
   getGroupSet( index?: number ): Object;
-  getGroupArray( name: string, index?: number ): Array<any>;
+  getGroupArray( name: string, index?: number ): Array<number>;
   initializeArray( name: string, type: string ): void;
   clear(): void;
   delete( key: string ): void;
@@ -137,17 +137,17 @@ export class TriangleIntersectData {
 
   constructor( tri: Triangle );
   addTriangle( index: number, tri: Triangle ): void;
-  getIntersectArray(): Array<any>;
+  getIntersectArray(): Array<Triangle>;
 
 }
 
 export class TriangleIntersectionSets {
 
   addTriangleIntersection( ia: number, tribA: Triangle, ib: number, triB: Triangle ): void;
-  getTrianglesAsArray( id?: number ): Array<any>;
+  getTrianglesAsArray( id?: number ): Array<Triangle>;
   getTriangleIndices(): Array<number>;
   getIntersectionIndices( id: number );
-  getIntersectionsAsArray( id?: number, id2?: number ): Array<any>;
+  getIntersectionsAsArray( id?: number, id2?: number ): Array<Triangle>;
 
 }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -18,7 +18,7 @@ export class TypedAttributeData {
   getType( name: String ): string;
   getTotalLength( name: String ): number;
   getGroupSet( index?: number ): Object;
-  getGroupArray( name: string, index?: number ): Array; // return Array ???
+  getGroupArray( name: string, index?: number ): Array<any>;
   initializeArray( name: string, type: string ): void;
   clear(): void;
   delete( key: string ): void;
@@ -137,17 +137,17 @@ export class TriangleIntersectData {
 
   constructor( tri: Triangle );
   addTriangle( index: number, tri: Triangle ): void;
-  getIntersectArray(): Array;
+  getIntersectArray(): Array<any>;
 
 }
 
 export class TriangleIntersectionSets {
 
   addTriangleIntersection( ia: number, tribA: Triangle, ib: number, triB: Triangle ): void;
-  getTrianglesAsArray( id?: number ): Array;
-  getTriangleIndices(): Array;
+  getTrianglesAsArray( id?: number ): Array<any>;
+  getTriangleIndices(): Array<number>;
   getIntersectionIndices( id: number );
-  getIntersectionsAsArray( id?: number, id2: number ): Array;
+  getIntersectionsAsArray( id?: number, id2?: number ): Array<any>;
 
 }
 


### PR DESCRIPTION
Related to #82 . As mentioned in the issue, Array generics have been provided with types. Most of them are 'any', but after some analysis I could add 'number' to one of them. I've also fixed the optional parameter issue.