### PR TITLE
Hollow ops optimization

### DIFF
--- a/examples/geometry.js
+++ b/examples/geometry.js
@@ -12,6 +12,8 @@ import {
 	REVERSE_SUBTRACTION,
 	INTERSECTION,
 	DIFFERENCE,
+	HOLLOW_SUBTRACTION,
+	HOLLOW_INTERSECTION,
 } from '..';
 
 const params = {
@@ -184,7 +186,10 @@ async function init() {
 
 	// gui
 	gui = new GUI();
-	gui.add( params, 'operation', { ADDITION, SUBTRACTION, REVERSE_SUBTRACTION, INTERSECTION, DIFFERENCE } ).onChange( () => {
+	gui.add( params, 'operation', {
+		ADDITION, SUBTRACTION, REVERSE_SUBTRACTION, INTERSECTION,
+		DIFFERENCE, HOLLOW_SUBTRACTION, HOLLOW_INTERSECTION,
+	} ).onChange( () => {
 
 		updateCSG();
 


### PR DESCRIPTION
Skip the second triangle additions when only hollow ops are used as an optimization. Related to #162 