### PR TITLE
maxLeafTris -> maxLeafSize

### DIFF
--- a/src/core/Brush.js
+++ b/src/core/Brush.js
@@ -67,7 +67,7 @@ export class Brush extends Mesh {
 		if ( ! geometry.boundsTree ) {
 
 			ensureIndex( geometry, { useSharedArrayBuffer } );
-			geometry.boundsTree = new MeshBVH( geometry, { maxLeafTris: 3, indirect: true, useSharedArrayBuffer } );
+			geometry.boundsTree = new MeshBVH( geometry, { maxLeafSize: 3, indirect: true, useSharedArrayBuffer } );
 
 		}
 


### PR DESCRIPTION
`maxLeafTris` was deprecated in three-mesh-bvh v0.9.7 in favor of `maxLeafSize`. 

This PR updates the BVH construction in Brush.js to use the new option name. 