### PR TITLE
maxLeafSize -> targetLeafSize

### DIFF
--- a/src/core/Brush.js
+++ b/src/core/Brush.js
@@ -81,7 +81,7 @@ export class Brush extends Mesh {
 		}
 
 		// generate bounds tree
-		geometry.boundsTree = new MeshBVH( geometry, { maxLeafSize: 3, indirect: true, useSharedArrayBuffer } );
+		geometry.boundsTree = new MeshBVH( geometry, { targetLeafSize: 3, indirect: true, useSharedArrayBuffer } );
 
 		// generate half edges
 		if ( ! geometry.halfEdges ) {


### PR DESCRIPTION
`maxLeafSize` was deprecated in three-mesh-bvh v0.9.11 in favor of `targetLeafSize`.

This PR updates the BVH construction in Brush.js to use the new option name.